### PR TITLE
Increase the robustness of the create_package script

### DIFF
--- a/create_package.sh
+++ b/create_package.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eu
 
-export DEST="./packages"
+# Find the script location. Inspired by: https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+scriptLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+export DEST="${scriptLocation}/packages"
 
 rm -rf "${DEST}/*"
 mkdir -p "${DEST}"

--- a/create_package.sh
+++ b/create_package.sh
@@ -9,6 +9,6 @@ mkdir -p "${DEST}"
 for f in ${@};
 do
   FILENAME="$(basename "$f")"
-  echo "Create pacakge for ${FILENAME}"
+  echo "Create package for ${FILENAME}"
   tar cfz "${DEST}/${FILENAME}.tar.gz" "./keys/${FILENAME}" "./ips/${FILENAME}"
 done

--- a/create_package.sh
+++ b/create_package.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +xeu
+set -eu
 
 export DEST="./packages"
 

--- a/create_package.sh
+++ b/create_package.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-set +eu
+set +xeu
 
-export DEST="packages"
+export DEST="./packages"
 
-rm -rf packages/*
-mkdir -p packages
+rm -rf "${DEST}/*"
+mkdir -p "${DEST}"
 
-for f in ./ips/*;
+for f in ${@};
 do
   FILENAME="$(basename "$f")"
   echo "Create pacakge for ${FILENAME}"

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,6 @@ resource "null_resource" "cluster" {
   }
 
   provisioner "local-exec" {
-    command = "./create_package.sh"
+    command = "./create_package.sh ${join(" ", module.student_workspace.keys)}"
   }
 }

--- a/modules/student_workspace/outputs.tf
+++ b/modules/student_workspace/outputs.tf
@@ -1,0 +1,3 @@
+output "keys" {
+  value = "${local_file.public_ips.*.filename}"
+}


### PR DESCRIPTION
Since we use the filenames of the ip files from terraform, the script is run after all VMs are created. In my local setup the script was run as first step, hence creating an invalid `*.tar.gz` package