### PR TITLE
Add .rnd file to prevent openssl warning

### DIFF
--- a/modules/student_node/main.tf
+++ b/modules/student_node/main.tf
@@ -25,7 +25,8 @@ resource "google_compute_instance" "node" {
   apt-get update && apt-get install -y python
   modprobe br_netfilter && echo '1' > /proc/sys/net/ipv4/ip_forward
   echo -ne 'filetype plugin indent on\nset expandtab\nset tabstop=2\nset softtabstop=2\nset shiftwidth=2\nset softtabstop=2\n' > /home/student/.vimrc
-  echo 'alias tailf="tail -f"' >> /home/student/.bashrc"
+  echo 'alias tailf="tail -f"' >> /home/student/.bashrc
+  touch /home/student/.rnd"
 EOF
 
   metadata = {


### PR DESCRIPTION
Prevents the confusing warning:

```bash
Can't load /home/student/.rnd into RNG
140467358458304:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/home/student/.rnd
```